### PR TITLE
Update action plugin to fix _make_tmp_path issue

### DIFF
--- a/action_plugins/insights.py
+++ b/action_plugins/insights.py
@@ -6,9 +6,10 @@ class ActionModule(ActionBase):
 
     def run(self, tmp=None, task_vars=None):
         results = super(ActionModule, self).run(tmp, task_vars)
+        remote_user = task_vars.get('ansible_ssh_user') or self._play_context.remote_user
 
         # copy our egg
-        tmp = self._make_tmp_path()
+        tmp = self._make_tmp_path(remote_user)
         source_full = self._loader.get_real_file("falafel-1.35.0-py2.7.egg")
         tmp_src = self._connection._shell.join_path(tmp, 'insights')
         remote_path = self._transfer_file(source_full, tmp_src)


### PR DESCRIPTION
_make_tmp_path expects 2 arguments. One of those is the remote_user.
Add two lines to the action plugin to look at the ansible playbook
or config to get that value.